### PR TITLE
Update jenkins.pp

### DIFF
--- a/ci-setup/manifests/jenkins.pp
+++ b/ci-setup/manifests/jenkins.pp
@@ -8,7 +8,7 @@ class { 'jenkins' :
 
 # install a bunch of useful plugins
 $plugins = [
-  'credentials',
+  '::credentials',
   'ssh-credentials',
   'git-client',
   'scm-api',


### PR DESCRIPTION
vagrant up failed and jenkins did not start. It seems due to duplicate credential plugin, modifed plugin declaration to have :: credentials
