### PR TITLE
Typo, Errata, Links

### DIFF
--- a/Errata.md
+++ b/Errata.md
@@ -8,7 +8,7 @@ Kapitel 2 Continuous Delivery: Was und wie?
 
 ### 2.3 Werte von  Continuous Delivery
 
-Buch, p. 16: Regression
+Buch, p. 16, Abschnitt Regression:
 ... Sollte ein Fehler es dennoch
 bis in die Produktion schaffe, so kann er immer noch durch...
 
@@ -21,7 +21,7 @@ Kapitel 3 Infrastruktur bereitstellen
 
 ### 3.11 Links & Literatur
 
-Buch, p. 83: Link [2]
+Buch, p. 83:
 [2] http://community.opscode.com/cookbooks
 
 Ist umgezogen auf:

--- a/Errata.md
+++ b/Errata.md
@@ -1,0 +1,30 @@
+Errata für das Continuous Delivery Buch (2. Auflage)
+=========================
+
+In dieser Datei finden sich die Errata für das [Continuous Delivery Buch](http://continuous-delivery-buch.de/).
+
+Kapitel 2 Continuous Delivery: Was und wie?
+-----------------
+
+### 2.3 Werte von  Continuous Delivery
+
+Buch, p. 16: Regression
+... Sollte ein Fehler es dennoch
+bis in die Produktion schaffe, so kann er immer noch durch...
+
+Richtig wäre:  
+... Sollte ein Fehler es dennoch
+bis in die Produktion schaffen, so kann er immer noch durch...
+
+Kapitel 3 Infrastruktur bereitstellen
+-----------------
+
+### 3.11 Links & Literatur
+
+Buch, p. 83: Link [2]
+[2] http://community.opscode.com/cookbooks
+
+Ist umgezogen auf:
+[2] https://supermarket.chef.io/cookbooks
+
+

--- a/chef/LIESMICH.md
+++ b/chef/LIESMICH.md
@@ -1,6 +1,8 @@
 Java-Beispiel mit Chef
 =============================
 
+[English / Englisch](README.md)
+
 Dieses Beispiel zeigt, wie Chef genutzt werden kann, um eine Java-Umgebung zu konfigurieren.
 
 Das Vagrantfile kann genutzt werden, um eine Java-Anwendung in einer
@@ -30,4 +32,6 @@ Um es zu benutzen:
 * Jetzt kannst Du mit  `knife ec2 server create -r
   'role[tomcatserver]' --identity-file ~/.ssh/<schluessel>.pem`
   einen neuen Server installieren
+
+Die Anwendung steht unter http://localhost:18080/demo/ bereit.
 

--- a/chef/README.md
+++ b/chef/README.md
@@ -31,3 +31,6 @@ To use it:
 * Upload the role with `knife role from file roles/tomcatserver.json`
 * Now create a new server with   `knife ec2 server create -r
   'role[tomcatserver]' --identity-file ~/.ssh/<your-key>.pem`
+
+The application can be accessed at http://localhost:18080/demo/ .
+

--- a/chef/cookbooks/tomcat/attributes/default.rb
+++ b/chef/cookbooks/tomcat/attributes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: jetty
+# Cookbook Name:: tomcat
 # Attributes:: default
 #
 # Copyright 2010, Opscode, Inc.

--- a/shell/LIESMICH.md
+++ b/shell/LIESMICH.md
@@ -1,7 +1,7 @@
 Sample Java Project with Chef
 =============================
 
-[German / Deutsch](LIESMICH.md)
+[English / Englisch](README.md)
 
 Dieses Beispiel zeigt, wie Chef genutzt werden kann, um eine Java-Umgebung zu konfigurieren.
 


### PR DESCRIPTION
I just added an Errata file for the book with two entries.
Changed some navigation in German version of the readme file (links back to English now).
Added the information where to find the demo in the chef example.
And changed the cookbook name for the tomcat example from "jetty" to "tomcat".